### PR TITLE
feat(chart)!: rebrand ebpf-agent chart to kubeadapt-k8s-pulse

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains the Helm charts for deploying Kubeadapt into Kubernetes clusters:
 
 - **kubeadapt** - Main chart. Deploys the Kubeadapt agent (cluster metrics collection), with optional auto-upgrade sidecar and eBPF network agent subchart.
-- **ebpf-agent** - Standalone chart for the eBPF network metrics DaemonSet. Usually installed as a dependency of the main chart, but can be deployed independently.
+- **kubeadapt-k8s-pulse** - Standalone chart for the eBPF network metrics DaemonSet. Usually installed as a dependency of the main chart, but can be deployed independently.
 
 ## Platform Support
 

--- a/charts/kubeadapt-k8s-pulse/Chart.yaml
+++ b/charts/kubeadapt-k8s-pulse/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
-name: ebpf-agent
+name: kubeadapt-k8s-pulse
 description: High-performance eBPF-based network metrics agent for Kubernetes
 type: application
-version: 0.2.1
-appVersion: "0.2.0"
+version: 1.0.0
+appVersion: "3.0.1"
 
-home: https://github.com/kubeadapt/ebpf-agent
+home: https://github.com/kubeadapt/kubeadapt-k8s-pulse
 sources:
-  - https://github.com/kubeadapt/ebpf-agent
+  - https://github.com/kubeadapt/kubeadapt-k8s-pulse
 
 maintainers:
   - name: "ugurcancaykara"
@@ -55,11 +55,11 @@ annotations:
         note: "Full IPv4+IPv6 dual-stack support on kernel 5.10+"
   artifacthub.io/links: |
     - name: Documentation
-      url: https://github.com/kubeadapt/ebpf-agent/blob/main/README.md
+      url: https://github.com/kubeadapt/kubeadapt-k8s-pulse/blob/main/README.md
     - name: Architecture
-      url: https://github.com/kubeadapt/ebpf-agent/blob/main/docs/ARCHITECTURE.md
+      url: https://github.com/kubeadapt/kubeadapt-k8s-pulse/blob/main/docs/ARCHITECTURE.md
     - name: Source Code
-      url: https://github.com/kubeadapt/ebpf-agent
+      url: https://github.com/kubeadapt/kubeadapt-k8s-pulse
   artifacthub.io/images: |
-    - name: ebpf-agent
-      image: public.ecr.aws/w3l5x6r6/kubeadapt/app/kubeadapt-ebpf-agent:v0.2.0
+    - name: kubeadapt-k8s-pulse
+      image: public.ecr.aws/k2x0t8t6/kubeadapt/app/kubeadapt-k8s-pulse:v3.0.1

--- a/charts/kubeadapt-k8s-pulse/README.md
+++ b/charts/kubeadapt-k8s-pulse/README.md
@@ -1,6 +1,6 @@
-# ebpf-agent
+# kubeadapt-k8s-pulse
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 3.0.1](https://img.shields.io/badge/AppVersion-3.0.1-informational?style=flat-square)
 
 High-performance eBPF-based network metrics agent for Kubernetes
 
@@ -33,31 +33,31 @@ helm repo update
 Or use OCI registry:
 
 ```console
-helm pull oci://ghcr.io/kubeadapt/kubeadapt-helm/ebpf-agent --version 0.2.1
+helm pull oci://ghcr.io/kubeadapt/kubeadapt-helm/kubeadapt-k8s-pulse --version 1.0.0
 ```
 
 ## Installing the Chart
 
-To install the chart with the release name `kubeadapt-ebpf-agent`:
+To install the chart with the release name `kubeadapt-k8s-pulse`:
 
 ```console
-helm install kubeadapt-ebpf-agent kubeadapt/ebpf-agent -n kubeadapt --create-namespace
+helm install kubeadapt-k8s-pulse kubeadapt/kubeadapt-k8s-pulse -n kubeadapt --create-namespace
 ```
 
 Or via OCI:
 
 ```console
-helm install kubeadapt-ebpf-agent oci://ghcr.io/kubeadapt/kubeadapt-helm/ebpf-agent -n kubeadapt --create-namespace
+helm install kubeadapt-k8s-pulse oci://ghcr.io/kubeadapt/kubeadapt-helm/kubeadapt-k8s-pulse -n kubeadapt --create-namespace
 ```
 
-> **Note:** Using `kubeadapt-ebpf-agent` as release name ensures the service name matches Prometheus scrape configurations.
+> **Note:** Using `kubeadapt-k8s-pulse` as release name ensures the service name matches Prometheus scrape configurations.
 
 ## Uninstalling the Chart
 
 To uninstall/delete the deployment:
 
 ```console
-helm delete kubeadapt-ebpf-agent -n kubeadapt
+helm delete kubeadapt-k8s-pulse -n kubeadapt
 ```
 
 ## Security Requirements
@@ -118,8 +118,8 @@ Additionally requires:
 | enabled | bool | `true` |  |
 | env | list | `[]` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"public.ecr.aws/w3l5x6r6/kubeadapt/app/kubeadapt-ebpf-agent"` |  |
-| image.tag | string | `"v0.2.0"` |  |
+| image.repository | string | `"public.ecr.aws/k2x0t8t6/kubeadapt/app/kubeadapt-k8s-pulse"` |  |
+| image.tag | string | `"v3.0.1"` |  |
 | nodeSelector | object | `{}` |  |
 | resources.limits.cpu | string | `"500m"` |  |
 | resources.limits.memory | string | `"384Mi"` |  |
@@ -153,7 +153,7 @@ sudo bpftool map list | grep connection_flows
 
 Via **kubectl**:
 ```bash
-kubectl logs -n kubeadapt -l app.kubernetes.io/name=ebpf-agent --tail=50
-kubectl port-forward -n kubeadapt daemonset/kubeadapt-ebpf-agent 9090:9090
+kubectl logs -n kubeadapt -l app.kubernetes.io/name=kubeadapt-k8s-pulse --tail=50
+kubectl port-forward -n kubeadapt daemonset/kubeadapt-k8s-pulse 9090:9090
 curl http://localhost:9090/metrics | grep kubeadapt
 ```

--- a/charts/kubeadapt-k8s-pulse/README.md.gotmpl
+++ b/charts/kubeadapt-k8s-pulse/README.md.gotmpl
@@ -38,26 +38,26 @@ helm pull oci://ghcr.io/kubeadapt/kubeadapt-helm/{{ .Name }} --version {{ .Versi
 
 ## Installing the Chart
 
-To install the chart with the release name `kubeadapt-ebpf-agent`:
+To install the chart with the release name `kubeadapt-k8s-pulse`:
 
 ```console
-helm install kubeadapt-ebpf-agent kubeadapt/{{ .Name }} -n kubeadapt --create-namespace
+helm install kubeadapt-k8s-pulse kubeadapt/{{ .Name }} -n kubeadapt --create-namespace
 ```
 
 Or via OCI:
 
 ```console
-helm install kubeadapt-ebpf-agent oci://ghcr.io/kubeadapt/kubeadapt-helm/{{ .Name }} -n kubeadapt --create-namespace
+helm install kubeadapt-k8s-pulse oci://ghcr.io/kubeadapt/kubeadapt-helm/{{ .Name }} -n kubeadapt --create-namespace
 ```
 
-> **Note:** Using `kubeadapt-ebpf-agent` as release name ensures the service name matches Prometheus scrape configurations.
+> **Note:** Using `kubeadapt-k8s-pulse` as release name ensures the service name matches Prometheus scrape configurations.
 
 ## Uninstalling the Chart
 
 To uninstall/delete the deployment:
 
 ```console
-helm delete kubeadapt-ebpf-agent -n kubeadapt
+helm delete kubeadapt-k8s-pulse -n kubeadapt
 ```
 
 ## Security Requirements
@@ -128,7 +128,7 @@ sudo bpftool map list | grep connection_flows
 
 Via **kubectl**:
 ```bash
-kubectl logs -n kubeadapt -l app.kubernetes.io/name=ebpf-agent --tail=50
-kubectl port-forward -n kubeadapt daemonset/kubeadapt-ebpf-agent 9090:9090
+kubectl logs -n kubeadapt -l app.kubernetes.io/name=kubeadapt-k8s-pulse --tail=50
+kubectl port-forward -n kubeadapt daemonset/kubeadapt-k8s-pulse 9090:9090
 curl http://localhost:9090/metrics | grep kubeadapt
 ```

--- a/charts/kubeadapt-k8s-pulse/ci/default-values.yaml
+++ b/charts/kubeadapt-k8s-pulse/ci/default-values.yaml
@@ -1,12 +1,12 @@
-# Default CI values for ebpf-agent chart testing
+# Default CI values for kubeadapt-k8s-pulse chart testing
 # Used by chart-testing (ct) for lint and install validation
 
 # Enable the agent for CI testing
 enabled: true
 
 image:
-  repository: public.ecr.aws/w3l5x6r6/kubeadapt/app/kubeadapt-ebpf-agent
-  tag: "v0.1.1"
+  repository: public.ecr.aws/k2x0t8t6/kubeadapt/app/kubeadapt-k8s-pulse
+  tag: "v3.0.1"
   pullPolicy: Always  # Always pull to avoid stale cache in CI
 
 serviceAccount:

--- a/charts/kubeadapt-k8s-pulse/templates/_helpers.tpl
+++ b/charts/kubeadapt-k8s-pulse/templates/_helpers.tpl
@@ -1,14 +1,14 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "ebpf-agent.name" -}}
+{{- define "kubeadapt-k8s-pulse.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Create a default fully qualified app name.
 */}}
-{{- define "ebpf-agent.fullname" -}}
+{{- define "kubeadapt-k8s-pulse.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -24,16 +24,16 @@ Create a default fully qualified app name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "ebpf-agent.chart" -}}
+{{- define "kubeadapt-k8s-pulse.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "ebpf-agent.labels" -}}
-helm.sh/chart: {{ include "ebpf-agent.chart" . }}
-{{ include "ebpf-agent.selectorLabels" . }}
+{{- define "kubeadapt-k8s-pulse.labels" -}}
+helm.sh/chart: {{ include "kubeadapt-k8s-pulse.chart" . }}
+{{ include "kubeadapt-k8s-pulse.selectorLabels" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
@@ -43,18 +43,18 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{/*
 Selector labels
 */}}
-{{- define "ebpf-agent.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "ebpf-agent.name" . }}
+{{- define "kubeadapt-k8s-pulse.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubeadapt-k8s-pulse.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/component: ebpf-agent
+app.kubernetes.io/component: kubeadapt-k8s-pulse
 {{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "ebpf-agent.serviceAccountName" -}}
+{{- define "kubeadapt-k8s-pulse.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "ebpf-agent.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "kubeadapt-k8s-pulse.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/charts/kubeadapt-k8s-pulse/templates/daemonset.yaml
+++ b/charts/kubeadapt-k8s-pulse/templates/daemonset.yaml
@@ -2,13 +2,13 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ include "ebpf-agent.fullname" . }}
+  name: {{ include "kubeadapt-k8s-pulse.fullname" . }}
   labels:
-    {{- include "ebpf-agent.labels" . | nindent 4 }}
+    {{- include "kubeadapt-k8s-pulse.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      {{- include "ebpf-agent.selectorLabels" . | nindent 6 }}
+      {{- include "kubeadapt-k8s-pulse.selectorLabels" . | nindent 6 }}
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -16,19 +16,19 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "ebpf-agent.selectorLabels" . | nindent 8 }}
+        {{- include "kubeadapt-k8s-pulse.selectorLabels" . | nindent 8 }}
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.config.metricsPort | quote }}
         prometheus.io/path: "/metrics"
     spec:
-      serviceAccountName: {{ include "ebpf-agent.serviceAccountName" . }}
+      serviceAccountName: {{ include "kubeadapt-k8s-pulse.serviceAccountName" . }}
       # Required for eBPF: access to host network namespace
       hostNetwork: true
       # Required for eBPF: access to host PID namespace for process tracking
       hostPID: true
       containers:
-        - name: ebpf-agent
+        - name: kubeadapt-k8s-pulse
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/charts/kubeadapt-k8s-pulse/templates/service.yaml
+++ b/charts/kubeadapt-k8s-pulse/templates/service.yaml
@@ -2,15 +2,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "ebpf-agent.fullname" . }}
+  name: {{ include "kubeadapt-k8s-pulse.fullname" . }}
   labels:
-    {{- include "ebpf-agent.labels" . | nindent 4 }}
+    {{- include "kubeadapt-k8s-pulse.labels" . | nindent 4 }}
 spec:
   # Headless service for per-pod Prometheus scraping
   # Each DaemonSet pod is scraped individually
   clusterIP: None
   selector:
-    {{- include "ebpf-agent.selectorLabels" . | nindent 4 }}
+    {{- include "kubeadapt-k8s-pulse.selectorLabels" . | nindent 4 }}
   ports:
     - name: metrics
       port: {{ .Values.config.metricsPort }}

--- a/charts/kubeadapt-k8s-pulse/templates/serviceaccount.yaml
+++ b/charts/kubeadapt-k8s-pulse/templates/serviceaccount.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "ebpf-agent.serviceAccountName" . }}
+  name: {{ include "kubeadapt-k8s-pulse.serviceAccountName" . }}
   labels:
-    {{- include "ebpf-agent.labels" . | nindent 4 }}
+    {{- include "kubeadapt-k8s-pulse.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/kubeadapt-k8s-pulse/upgrade-metadata.yaml
+++ b/charts/kubeadapt-k8s-pulse/upgrade-metadata.yaml
@@ -2,7 +2,7 @@
 # Defines explicit upgrade paths for this chart version.
 # This file is embedded in the chart package and used by KubeAdapt auto-upgrade system.
 
-chartVersion: "0.2.1"
+chartVersion: "1.0.0"
 
 # Versions that can upgrade to this version
 upgradeFrom:
@@ -20,7 +20,7 @@ channels:
 
 # Optional metadata
 metadata:
-  releaseNotes: "https://github.com/kubeadapt/kubeadapt-helm/releases/tag/ebpf-agent-0.2.1"
+  releaseNotes: "https://github.com/kubeadapt/kubeadapt-helm/releases/tag/kubeadapt-k8s-pulse-1.0.0"
   containsSecurityUpdates: false
   minKubernetesVersion: "1.24.0"
   minKernelVersion: "5.10"

--- a/charts/kubeadapt-k8s-pulse/values.yaml
+++ b/charts/kubeadapt-k8s-pulse/values.yaml
@@ -5,8 +5,8 @@
 enabled: true
 
 image:
-  repository: public.ecr.aws/w3l5x6r6/kubeadapt/app/kubeadapt-ebpf-agent
-  tag: "v0.2.0"
+  repository: public.ecr.aws/k2x0t8t6/kubeadapt/app/kubeadapt-k8s-pulse
+  tag: "v3.0.1"
   pullPolicy: Always
 
 serviceAccount:


### PR DESCRIPTION
BREAKING CHANGE: chart renamed from ebpf-agent to kubeadapt-k8s-pulse, image registry alias and image name changed.

- Chart name: ebpf-agent -> kubeadapt-k8s-pulse
- Chart version: 0.2.1 -> 1.0.0
- Chart appVersion: 0.2.0 -> 3.0.1
- Image: public.ecr.aws/w3l5x6r6/kubeadapt/app/kubeadapt-ebpf-agent:v0.2.0 -> public.ecr.aws/k2x0t8t6/kubeadapt/app/kubeadapt-k8s-pulse:v3.0.1
- Template helper names: ebpf-agent.* -> kubeadapt-k8s-pulse.*
- Container/component label: ebpf-agent -> kubeadapt-k8s-pulse
- Source repo: github.com/kubeadapt/ebpf-agent -> github.com/kubeadapt/kubeadapt-k8s-pulse

The kubeadapt umbrella chart's dependency reference will be updated to kubeadapt-k8s-pulse 1.0.0 in a follow-up PR.

<!--
Note on Signed Commits:

All commits must be signed. If the DCO check fails, please sign your commits using `git commit -s` or `git commit --signoff`.
-->

Checklist:

* [X] I have bumped the chart version according to semantic versioning
* [X] I have updated the documentation
* [X] I have updated the chart changelog in Chart.yaml annotations
* [X] Any new values are backwards compatible and/or have sensible defaults
* [X] I have signed all my commits
* [X] All CI checks are passing

Changes:
<!-- Please provide a brief description of the changes in this PR -->

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
