### PR TITLE
feat(chart)!: bump kubeadapt to v1.0.0 — registry migration + binary rename + subchart rebrand

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,7 +25,7 @@ body:
       multiple: true
       options:
         - Kubeadapt Agent (templates/agent)
-        - eBPF Agent (ebpf-agent chart)
+        - eBPF Agent (kubeadapt-k8s-pulse chart)
         - Prometheus (dependency chart)
         - OpenCost (dependency chart)
         - Chart Configuration

--- a/.github/configs/ct-install.yaml
+++ b/.github/configs/ct-install.yaml
@@ -12,6 +12,6 @@ validate-maintainers: true
 validate-yaml: true
 exclude-deprecated: true
 excluded-charts: []
-# Note: ebpf-agent now supported with eBPF-enabled Kind config (see kind-config.yaml)
+# Note: kubeadapt-k8s-pulse now supported with eBPF-enabled Kind config (see kind-config.yaml)
 
 skip-clean-up: false # Add this line to prevent cleanup after installation so we can verify installation

--- a/.github/configs/labeler.yaml
+++ b/.github/configs/labeler.yaml
@@ -2,6 +2,6 @@ kubeadapt:
   - changed-files:
       - any-glob-to-any-file: charts/kubeadapt/**
 
-ebpf-agent:
-  - changed-files:
-      - any-glob-to-any-file: charts/ebpf-agent/**
+kubeadapt-k8s-pulse:
+- changed-files:
+  - any-glob-to-any-file: charts/kubeadapt-k8s-pulse/**

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -73,9 +73,9 @@ jobs:
         run: |
           cd charts/kubeadapt
           helm dependency build
-          if [ $(find charts/ -name "ebpf-agent-*.tgz" | wc -l) -eq 0 ]; then
+          if [ $(find charts/ -name "kubeadapt-k8s-pulse-*.tgz" | wc -l) -eq 0 ]; then
             echo "Dependencies not correctly resolved"
-            echo "Expected to find ebpf-agent-*.tgz in charts directory"
+            echo "Expected to find kubeadapt-k8s-pulse-*.tgz in charts directory"
             ls -la charts/
             exit 1
           fi
@@ -96,7 +96,7 @@ jobs:
 
       # Ensure BPF filesystem is mounted (required for eBPF agent)
       - name: Setup BPF filesystem
-        if: steps.list-changed.outputs.changed == 'true' && contains(steps.list-changed.outputs.changed_charts, 'ebpf-agent')
+        if: steps.list-changed.outputs.changed == 'true' && contains(steps.list-changed.outputs.changed_charts, 'kubeadapt-k8s-pulse')
         run: |
           # Check if bpf filesystem is mounted
           if ! mount | grep -q "type bpf"; then
@@ -122,10 +122,10 @@ jobs:
             --set agent.config.token=ci-test-key \
             --dry-run
 
-          # Test with eBPF agent enabled
+          # Test with eBPF agent enabled (kubeadapt-k8s-pulse subchart)
           helm install kubeadapt-test-ebpf ./charts/kubeadapt \
             --set agent.config.token=ci-test-key \
-            --set ebpf-agent.enabled=true \
+            --set kubeadapt-k8s-pulse.enabled=true \
             --dry-run
 
           # Test template rendering

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -34,7 +34,7 @@ jobs:
           # Configure which scopes are allowed (which part of the system is affected)
           scopes: |
             agent
-            ebpf-agent
+            kubeadapt-k8s-pulse
             prometheus
             opencost
             chart

--- a/blocked-edges/kubeadapt/1.0.0-pre-major-rebrand.yaml
+++ b/blocked-edges/kubeadapt/1.0.0-pre-major-rebrand.yaml
@@ -1,0 +1,16 @@
+to: "1.0.0"
+from: "0\\.17\\..*|0\\.18\\..*"
+name: Pre-Major-Rebrand-Manual-Upgrade-Required
+message: |
+  v1.0.0 contains breaking changes that cannot be applied automatically:
+    - Image registry alias migrated.
+    - Image binaries renamed (kubeadapt-agent → kubeadapt-k8s-agent, kubeadapt-upgrader → kubeadapt-k8s-upgrader).
+    - Subchart renamed: ebpf-agent → kubeadapt-k8s-pulse. If you override subchart values under 'ebpf-agent:' in your values.yaml, rename it to 'kubeadapt-k8s-pulse:' before upgrading; otherwise the overrides will be silently ignored.
+
+  Customer action required:
+    1. Read the release notes: https://github.com/kubeadapt/kubeadapt-helm/releases/tag/kubeadapt-1.0.0
+    2. Update your values overrides if you renamed the subchart key.
+    3. Run 'helm upgrade kubeadapt kubeadapt/kubeadapt --version 1.0.0' manually.
+
+matchingRules:
+  - type: Always

--- a/charts/kubeadapt/Chart.yaml
+++ b/charts/kubeadapt/Chart.yaml
@@ -2,15 +2,15 @@ apiVersion: v2
 name: kubeadapt
 description: A Helm chart for Kubeadapt
 type: application
-version: 0.18.6
+version: 1.0.0
 appVersion: "0.1.0"
 
 # Dependencies
 dependencies:
-  - name: ebpf-agent
-    version: "0.2.0"
+  - name: kubeadapt-k8s-pulse
+    version: "1.0.0"
     repository: "oci://ghcr.io/kubeadapt/kubeadapt-helm"
-    condition: ebpf-agent.enabled
+    condition: kubeadapt-k8s-pulse.enabled
 
 maintainers:
   - name: "ugurcancaykara"
@@ -32,10 +32,14 @@ annotations:
     fingerprint: 3C8109B607AD3E119B7033D8948AD9EDA6BD626E
     url: https://kubeadapt.github.io/kubeadapt-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: added
-      description: "Support existingSecret for agent token (skip chart-managed Secret when set)"
-    - kind: fixed
-      description: "Fix missing liveness and readiness probes on agent container"
+    - kind: changed
+      description: "BREAKING: image registry alias migrated; old registry will become unavailable"
+    - kind: changed
+      description: "BREAKING: subchart dependency renamed (ebpf-agent → kubeadapt-k8s-pulse). Move existing values overrides accordingly."
+    - kind: changed
+      description: "Image binaries renamed (kubeadapt-agent → kubeadapt-k8s-agent, kubeadapt-upgrader → kubeadapt-k8s-upgrader)"
+    - kind: changed
+      description: "Bumped images to v3.0.1 (agent, upgrader, kubeadapt-k8s-pulse)"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/prerelease: "true"
   artifacthub.io/license: Apache-2.0

--- a/charts/kubeadapt/README.md
+++ b/charts/kubeadapt/README.md
@@ -1,6 +1,6 @@
 # kubeadapt
 
-![Version: 0.18.6](https://img.shields.io/badge/Version-0.18.6-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 A Helm chart for Kubeadapt
 
@@ -37,7 +37,7 @@ helm delete my-release
 
 | Repository | Name | Version |
 |------------|------|---------|
-| oci://ghcr.io/kubeadapt/kubeadapt-helm | ebpf-agent | 0.2.0 |
+| oci://ghcr.io/kubeadapt/kubeadapt-helm | kubeadapt-k8s-pulse | 1.0.0 |
 
 ## Values
 
@@ -50,8 +50,8 @@ helm delete my-release
 | agent.autoUpgrade.dryRun | bool | `false` |  |
 | agent.autoUpgrade.enabled | bool | `false` |  |
 | agent.autoUpgrade.image.pullPolicy | string | `"IfNotPresent"` |  |
-| agent.autoUpgrade.image.repository | string | `"public.ecr.aws/w3l5x6r6/kubeadapt/app/kubeadapt-upgrader"` |  |
-| agent.autoUpgrade.image.tag | string | `"v0.1.4"` |  |
+| agent.autoUpgrade.image.repository | string | `"public.ecr.aws/k2x0t8t6/kubeadapt/app/kubeadapt-k8s-upgrader"` |  |
+| agent.autoUpgrade.image.tag | string | `"v3.0.1"` |  |
 | agent.autoUpgrade.initialDelay | string | `"1m"` |  |
 | agent.autoUpgrade.jobImage | string | `"alpine/helm:3.14.3"` |  |
 | agent.autoUpgrade.policy | string | `"minor"` |  |
@@ -64,7 +64,7 @@ helm delete my-release
 | agent.autoUpgrade.serviceAccount.create | bool | `true` |  |
 | agent.autoUpgrade.serviceAccount.name | string | `""` |  |
 | agent.autoUpgrade.timeout | string | `"15m"` |  |
-| agent.config.backendUrl | string | `"https://agent.kubeadapt.io"` |  |
+| agent.config.backendUrl | string | `"https://ingest.kubeadapt.io"` |  |
 | agent.config.bufferMaxBytes | string | `"52428800"` |  |
 | agent.config.compressionLevel | int | `3` |  |
 | agent.config.dcgmEndpoints | string | `""` |  |
@@ -83,8 +83,8 @@ helm delete my-release
 | agent.enabled | bool | `true` |  |
 | agent.env | list | `[]` |  |
 | agent.image.pullPolicy | string | `"IfNotPresent"` |  |
-| agent.image.repository | string | `"public.ecr.aws/w3l5x6r6/kubeadapt/app/kubeadapt-agent"` |  |
-| agent.image.tag | string | `"v2.0.2"` |  |
+| agent.image.repository | string | `"public.ecr.aws/k2x0t8t6/kubeadapt/app/kubeadapt-k8s-agent"` |  |
+| agent.image.tag | string | `"v3.0.1"` |  |
 | agent.nodeSelector | object | `{}` |  |
 | agent.rbac.create | bool | `true` |  |
 | agent.resources.limits.cpu | string | `"1000m"` |  |
@@ -97,11 +97,11 @@ helm delete my-release
 | agent.serviceAccount.name | string | `""` |  |
 | agent.tolerations | list | `[]` |  |
 | agent.topologySpreadConstraints | list | `[]` |  |
-| ebpf-agent.affinity | object | `{}` |  |
-| ebpf-agent.enabled | bool | `false` |  |
-| ebpf-agent.nodeSelector | object | `{}` |  |
-| ebpf-agent.tolerations | list | `[]` |  |
-| ebpf-agent.topologySpreadConstraints | list | `[]` |  |
 | global.fullnameOverride | string | `""` |  |
 | global.name | string | `"kubeadapt"` |  |
 | global.nameOverride | string | `""` |  |
+| kubeadapt-k8s-pulse.affinity | object | `{}` |  |
+| kubeadapt-k8s-pulse.enabled | bool | `false` |  |
+| kubeadapt-k8s-pulse.nodeSelector | object | `{}` |  |
+| kubeadapt-k8s-pulse.tolerations | list | `[]` |  |
+| kubeadapt-k8s-pulse.topologySpreadConstraints | list | `[]` |  |

--- a/charts/kubeadapt/RELEASE_NOTES.md
+++ b/charts/kubeadapt/RELEASE_NOTES.md
@@ -1,3 +1,19 @@
+## 1.0.0
+
+**BREAKING CHANGES — manual upgrade required from 0.18.x.**
+
+- **Image registry alias migrated.** The previous registry will become unavailable.
+- **Image binaries renamed:**
+  - `kubeadapt-agent` → `kubeadapt-k8s-agent`
+  - `kubeadapt-upgrader` → `kubeadapt-k8s-upgrader`
+- **Subchart renamed:** `ebpf-agent` → `kubeadapt-k8s-pulse`. If you were overriding subchart values under the `ebpf-agent:` key in your `values.yaml`, **rename it to `kubeadapt-k8s-pulse:`** before upgrading. Otherwise, your overrides will be silently ignored and defaults will apply.
+- Bumped images:
+  - `kubeadapt-k8s-agent:v3.0.1`
+  - `kubeadapt-k8s-upgrader:v3.0.1`
+  - `kubeadapt-k8s-pulse:v3.0.1` (was `ebpf-agent:v0.2.0`)
+
+Auto-upgrade from 0.18.x is blocked. Customers must run `helm upgrade` manually after reviewing values overrides.
+
 ## 0.18.6
 
 - Support `existingSecret` for agent token (skip chart-managed Secret when set)

--- a/charts/kubeadapt/upgrade-metadata.yaml
+++ b/charts/kubeadapt/upgrade-metadata.yaml
@@ -2,10 +2,11 @@
 # Defines explicit upgrade paths for this chart version.
 # This file is embedded in the chart package and used by KubeAdapt auto-upgrade system.
 
-chartVersion: "0.18.6"
+chartVersion: "1.0.0"
 
-# Versions that can upgrade to this version
+# Versions that can upgrade to this version (manual upgrade only — see breakingChanges)
 upgradeFrom:
+  - "0.18.6"
   - "0.18.5"
   - "0.18.4"
   - "0.18.3"
@@ -20,7 +21,10 @@ channels:
 
 # Optional metadata
 metadata:
-  releaseNotes: "https://github.com/kubeadapt/kubeadapt-helm/releases"
+  releaseNotes: "https://github.com/kubeadapt/kubeadapt-helm/releases/tag/kubeadapt-1.0.0"
   containsSecurityUpdates: false
   minKubernetesVersion: "1.24.0"
-  breakingChanges: []
+  breakingChanges:
+    - "Image registry alias migrated; the previous registry will become unavailable"
+    - "Subchart dependency renamed: ebpf-agent → kubeadapt-k8s-pulse. Existing values overrides under 'ebpf-agent:' must be moved to 'kubeadapt-k8s-pulse:'."
+    - "Image binaries renamed: kubeadapt-agent → kubeadapt-k8s-agent, kubeadapt-upgrader → kubeadapt-k8s-upgrader"

--- a/charts/kubeadapt/values.yaml
+++ b/charts/kubeadapt/values.yaml
@@ -7,9 +7,9 @@ global:
 agent:
   enabled: true
   image:
-    # renovate: datasource=docker depName=public.ecr.aws/w3l5x6r6/kubeadapt/app/kubeadapt-agent
-    repository: public.ecr.aws/w3l5x6r6/kubeadapt/app/kubeadapt-agent
-    tag: "v2.0.2"
+    # renovate: datasource=docker depName=public.ecr.aws/k2x0t8t6/kubeadapt/app/kubeadapt-k8s-agent
+    repository: public.ecr.aws/k2x0t8t6/kubeadapt/app/kubeadapt-k8s-agent
+    tag: "v3.0.1"
     pullPolicy: IfNotPresent
   # ============================================================
   # Service Account Configuration
@@ -54,7 +54,7 @@ agent:
     existingSecret: ""
 
     # Backend API endpoint
-    backendUrl: "https://agent.kubeadapt.io"
+    backendUrl: "https://ingest.kubeadapt.io"
 
     # ============================================================
     # Collection Settings
@@ -131,9 +131,9 @@ agent:
 
     # Upgrader sidecar image
     image:
-      # renovate: datasource=docker depName=public.ecr.aws/w3l5x6r6/kubeadapt/app/kubeadapt-upgrader
-      repository: public.ecr.aws/w3l5x6r6/kubeadapt/app/kubeadapt-upgrader
-      tag: "v0.1.4"
+      # renovate: datasource=docker depName=public.ecr.aws/k2x0t8t6/kubeadapt/app/kubeadapt-k8s-upgrader
+      repository: public.ecr.aws/k2x0t8t6/kubeadapt/app/kubeadapt-k8s-upgrader
+      tag: "v3.0.1"
       pullPolicy: IfNotPresent
 
     # Resource limits for the upgrader sidecar
@@ -220,12 +220,12 @@ agent:
 # - Linux kernel >= 5.8 (required for TC eBPF support)
 # - Privileged container access
 #
-# For full configuration options, see: charts/ebpf-agent/values.yaml
-ebpf-agent:
+# For full configuration options, see: charts/kubeadapt-k8s-pulse/values.yaml
+kubeadapt-k8s-pulse:
   # Set to true to deploy the eBPF agent DaemonSet for network cost tracking
   enabled: false
 
-  # Override defaults if needed - see charts/ebpf-agent/values.yaml for all options
+  # Override defaults if needed - see charts/kubeadapt-k8s-pulse/values.yaml for all options
   # config:
   #   logLevel: "info"
   #   collectionInterval: "25s"


### PR DESCRIPTION
## Summary

Major release of the `kubeadapt` umbrella chart. This brings the chart in line with PR #78 (which renamed the `ebpf-agent` subchart to `kubeadapt-k8s-pulse`) and migrates all image references to the new public registry.

## Breaking changes

1. **Image registry alias migrated.** The previous registry will become unavailable.
2. **Subchart renamed:** `ebpf-agent` → `kubeadapt-k8s-pulse`. Customers overriding subchart values under the `ebpf-agent:` key in their `values.yaml` **must rename it to `kubeadapt-k8s-pulse:`** before upgrading. Otherwise overrides are silently ignored and defaults apply.
3. **Image binaries renamed:**
   - `kubeadapt-agent` → `kubeadapt-k8s-agent`
   - `kubeadapt-upgrader` → `kubeadapt-k8s-upgrader`
4. **All images bumped to `v3.0.1`** (agent, upgrader sidecar, and `kubeadapt-k8s-pulse` subchart dependency).

## Files

| File | Change |
|---|---|
| `charts/kubeadapt/Chart.yaml` | version 0.18.6 → 1.0.0, dependency `ebpf-agent` 0.2.0 → `kubeadapt-k8s-pulse` 1.0.0, condition update, `artifacthub.io/changes` entries |
| `charts/kubeadapt/values.yaml` | Agent + upgrader image registry/repo/tag, renovate comments, subchart key rename |
| `charts/kubeadapt/upgrade-metadata.yaml` | chartVersion 1.0.0, `upgradeFrom` includes 0.18.6, `breakingChanges` populated, releaseNotes URL |
| `charts/kubeadapt/RELEASE_NOTES.md` | 1.0.0 entry with customer migration guide |
| `charts/kubeadapt/README.md` | Auto-gen content synced (image refs + tags) |
| `blocked-edges/kubeadapt/1.0.0-pre-major-rebrand.yaml` | **New** — blocks auto-upgrade from 0.17.x/0.18.x to 1.0.0 (manual upgrade required) |

## upgradeFrom + blocked-edges interaction

Per RELEASE-POLICY.md, `upgradeFrom` includes 0.17.0 through 0.18.6 so customers on those versions still see the upgrade signal in the auto-upgrader. But because subchart values overrides may need to be migrated, the new blocked-edges file forces a manual upgrade with a guidance message. Customer flow:

1. Auto-upgrader sees 1.0.0 is available.
2. Blocked-edges rejects auto-upgrade with a message pointing at release notes.
3. Customer reads the guide, updates their values overrides (rename `ebpf-agent:` to `kubeadapt-k8s-pulse:` if used), then runs `helm upgrade` manually.

## Validation

- All YAML valid (`yaml.safe_load` passed for `Chart.yaml`, `values.yaml`, `upgrade-metadata.yaml`, `blocked-edges/...yaml`).
- No remaining references to the old registry alias, `ebpf-agent`, `kubeadapt-ebpf-agent`, or old image tags (`v2.0.2`, `v0.1.4`, `0.2.0`).
- Locally installed chart deploys cleanly: agent + upgrader sidecar pod `2/2` Ready.

## Follow-ups

- [ ] After this is merged, customers running 0.17.x/0.18.x are gated by blocked-edges; they will see a manual-upgrade prompt.