### PR TITLE
fix(chart): bump kubeadapt to v1.0.1 - allow installing in multiple namespaces

### DIFF
--- a/charts/kubeadapt/Chart.yaml
+++ b/charts/kubeadapt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kubeadapt
 description: A Helm chart for Kubeadapt
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "0.1.0"
 
 # Dependencies
@@ -32,14 +32,8 @@ annotations:
     fingerprint: 3C8109B607AD3E119B7033D8948AD9EDA6BD626E
     url: https://kubeadapt.github.io/kubeadapt-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: "BREAKING: image registry alias migrated; old registry will become unavailable"
-    - kind: changed
-      description: "BREAKING: subchart dependency renamed (ebpf-agent → kubeadapt-k8s-pulse). Move existing values overrides accordingly."
-    - kind: changed
-      description: "Image binaries renamed (kubeadapt-agent → kubeadapt-k8s-agent, kubeadapt-upgrader → kubeadapt-k8s-upgrader)"
-    - kind: changed
-      description: "Bumped images to v3.0.1 (agent, upgrader, kubeadapt-k8s-pulse)"
+    - kind: fixed
+      description: "Allow installing the chart in multiple namespaces simultaneously by suffixing cluster-scoped resource names (ClusterRole, ClusterRoleBinding) with the release namespace when it differs from the default 'kubeadapt' namespace. Existing installs in the default namespace are preserved unchanged."
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/prerelease: "true"
   artifacthub.io/license: Apache-2.0

--- a/charts/kubeadapt/README.md
+++ b/charts/kubeadapt/README.md
@@ -1,6 +1,6 @@
 # kubeadapt
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 A Helm chart for Kubeadapt
 

--- a/charts/kubeadapt/RELEASE_NOTES.md
+++ b/charts/kubeadapt/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+## 1.0.1
+
+- Fix install failure when deploying the chart into a non-default namespace alongside an existing install. Cluster-scoped resources (`ClusterRole`, `ClusterRoleBinding`) for the agent and upgrader are now suffixed with the release namespace when it differs from the chart's default namespace (`kubeadapt`), so multiple installs across namespaces no longer collide on cluster-wide resource names.
+- Existing installs in the `kubeadapt` namespace are unaffected — resource names are preserved and `helm upgrade` performs no renames.
+
 ## 1.0.0
 
 **BREAKING CHANGES — manual upgrade required from 0.18.x.**

--- a/charts/kubeadapt/templates/_helpers.tpl
+++ b/charts/kubeadapt/templates/_helpers.tpl
@@ -47,3 +47,22 @@ Selector labels
 app.kubernetes.io/name: {{ include "kubeadapt.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Suffix appended to cluster-scoped resource names (ClusterRole, ClusterRoleBinding)
+so multiple chart installs in different namespaces don't collide on the cluster-wide
+namespace. Cluster-scoped resources have no namespace and would otherwise share a
+single global name across all installs.
+
+Behaviour:
+  - When .Release.Namespace == kubeadapt.name (the chart's default namespace),
+    returns "" → resource names stay unchanged for backward compatibility with
+    existing installs (no resource renames on `helm upgrade`).
+  - Otherwise returns "-<release-namespace>" so each install in a non-default
+    namespace gets a unique cluster-scoped resource name.
+*/}}
+{{- define "kubeadapt.clusterResourceSuffix" -}}
+{{- if ne .Release.Namespace (include "kubeadapt.name" .) -}}
+-{{ .Release.Namespace }}
+{{- end -}}
+{{- end }}

--- a/charts/kubeadapt/templates/agent/rbac.yaml
+++ b/charts/kubeadapt/templates/agent/rbac.yaml
@@ -17,7 +17,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kubeadapt.name" . }}-agent
+  name: {{ include "kubeadapt.name" . }}-agent{{ include "kubeadapt.clusterResourceSuffix" . }}
   labels:
     {{- include "kubeadapt.labels" . | nindent 4 }}
     app.kubernetes.io/component: agent
@@ -131,14 +131,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "kubeadapt.name" . }}-agent
+  name: {{ include "kubeadapt.name" . }}-agent{{ include "kubeadapt.clusterResourceSuffix" . }}
   labels:
     {{- include "kubeadapt.labels" . | nindent 4 }}
     app.kubernetes.io/component: agent
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "kubeadapt.name" . }}-agent
+  name: {{ include "kubeadapt.name" . }}-agent{{ include "kubeadapt.clusterResourceSuffix" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "kubeadapt.name" . }}-agent

--- a/charts/kubeadapt/templates/agent/upgrader-rbac.yaml
+++ b/charts/kubeadapt/templates/agent/upgrader-rbac.yaml
@@ -92,7 +92,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kubeadapt.name" . }}-upgrader
+  name: {{ include "kubeadapt.name" . }}-upgrader{{ include "kubeadapt.clusterResourceSuffix" . }}
   labels:
     {{- include "kubeadapt.labels" . | nindent 4 }}
     app.kubernetes.io/component: upgrader
@@ -105,8 +105,8 @@ rules:
       - clusterroles
       - clusterrolebindings
     resourceNames:
-      - "{{ include "kubeadapt.name" . }}-agent"
-      - "{{ include "kubeadapt.name" . }}-upgrader"
+      - "{{ include "kubeadapt.name" . }}-agent{{ include "kubeadapt.clusterResourceSuffix" . }}"
+      - "{{ include "kubeadapt.name" . }}-upgrader{{ include "kubeadapt.clusterResourceSuffix" . }}"
     verbs: ["get", "list", "update", "patch", "delete", "escalate"]
   # Separate rule for create (resourceNames constraint not supported)
   - apiGroups: ["rbac.authorization.k8s.io"]
@@ -195,14 +195,14 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "kubeadapt.name" . }}-upgrader
+  name: {{ include "kubeadapt.name" . }}-upgrader{{ include "kubeadapt.clusterResourceSuffix" . }}
   labels:
     {{- include "kubeadapt.labels" . | nindent 4 }}
     app.kubernetes.io/component: upgrader
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "kubeadapt.name" . }}-upgrader
+  name: {{ include "kubeadapt.name" . }}-upgrader{{ include "kubeadapt.clusterResourceSuffix" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "kubeadapt.name" . }}-upgrader

--- a/charts/kubeadapt/upgrade-metadata.yaml
+++ b/charts/kubeadapt/upgrade-metadata.yaml
@@ -2,10 +2,11 @@
 # Defines explicit upgrade paths for this chart version.
 # This file is embedded in the chart package and used by KubeAdapt auto-upgrade system.
 
-chartVersion: "1.0.0"
+chartVersion: "1.0.1"
 
-# Versions that can upgrade to this version (manual upgrade only — see breakingChanges)
+# Versions that can upgrade to this version
 upgradeFrom:
+  - "1.0.0"
   - "0.18.6"
   - "0.18.5"
   - "0.18.4"
@@ -21,10 +22,7 @@ channels:
 
 # Optional metadata
 metadata:
-  releaseNotes: "https://github.com/kubeadapt/kubeadapt-helm/releases/tag/kubeadapt-1.0.0"
+  releaseNotes: "https://github.com/kubeadapt/kubeadapt-helm/releases/tag/kubeadapt-1.0.1"
   containsSecurityUpdates: false
   minKubernetesVersion: "1.24.0"
-  breakingChanges:
-    - "Image registry alias migrated; the previous registry will become unavailable"
-    - "Subchart dependency renamed: ebpf-agent → kubeadapt-k8s-pulse. Existing values overrides under 'ebpf-agent:' must be moved to 'kubeadapt-k8s-pulse:'."
-    - "Image binaries renamed: kubeadapt-agent → kubeadapt-k8s-agent, kubeadapt-upgrader → kubeadapt-k8s-upgrader"
+  breakingChanges: []


### PR DESCRIPTION
## Summary

- Suffix cluster-scoped resource names (`ClusterRole`, `ClusterRoleBinding`) for the agent and upgrader with the release namespace when it differs from the chart's default `kubeadapt` namespace
- Existing installs in the `kubeadapt` namespace are unaffected: names are preserved and `helm upgrade` performs no resource renames
- Bump chart to v1.0.1

## Why

Cluster-scoped resources were always named `kubeadapt-agent` / `kubeadapt-upgrader` regardless of release namespace, so a second install in a different namespace failed with:

```
ClusterRole "kubeadapt-agent" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-namespace" must equal "<new-ns>": current value is "<old-ns>"
```

## Files changed

- `charts/kubeadapt/templates/_helpers.tpl` - add `kubeadapt.clusterResourceSuffix` helper
- `charts/kubeadapt/templates/agent/rbac.yaml` - apply suffix to agent ClusterRole + ClusterRoleBinding + roleRef
- `charts/kubeadapt/templates/agent/upgrader-rbac.yaml` - apply suffix to upgrader ClusterRole + ClusterRoleBinding + roleRef + resourceNames
- `charts/kubeadapt/Chart.yaml` - version 1.0.0 -> 1.0.1; `artifacthub.io/changes` updated
- `charts/kubeadapt/upgrade-metadata.yaml` - chartVersion 1.0.1; prepend 1.0.0 to `upgradeFrom`; clear `breakingChanges`
- `charts/kubeadapt/RELEASE_NOTES.md` - 1.0.1 entry
- `charts/kubeadapt/README.md` - regenerated via `helm-docs`

## Verification

- `helm lint charts/kubeadapt` clean
- `helm template -n kubeadapt ...` renders cluster resources as `kubeadapt-agent` / `kubeadapt-upgrader` (legacy preserved)
- `helm template -n kubeadapts ...` renders cluster resources as `kubeadapt-agent-kubeadapts` / `kubeadapt-upgrader-kubeadapts` (no collision)