### PR TITLE
fix(ci): point agent ci values at the image that actually exists

### DIFF
--- a/charts/kubeadapt/ci/default-values.yaml
+++ b/charts/kubeadapt/ci/default-values.yaml
@@ -7,8 +7,8 @@ global:
 agent:
   enabled: true
   image:
-    repository: public.ecr.aws/w3l5x6r6/kubeadapt/app/kubeadapt-agent
-    tag: "v2.0.0"
+    repository: public.ecr.aws/k2x0t8t6/kubeadapt/app/kubeadapt-k8s-agent
+    tag: "v3.0.1"
     pullPolicy: IfNotPresent
   serviceAccount:
     create: true


### PR DESCRIPTION
## Problem

`ct install` has failed on **every pull request** in this repo since the #78 rebrand, burning ~11.5 minutes of CI each time before timing out.

The chart-testing values still pin the pre-rebrand image:

```yaml
repository: public.ecr.aws/w3l5x6r6/kubeadapt/app/kubeadapt-agent
tag: "v2.0.0"
```

That registry alias no longer resolves. Queried against public ECR:

| reference | result |
|---|---|
| `w3l5x6r6/kubeadapt/app/kubeadapt-agent` | `NAME_UNKNOWN` — repository does not exist |
| `k2x0t8t6/kubeadapt/app/kubeadapt-k8s-agent` | exists, tags include `v3.0.1` |

#78 renamed `kubeadapt-agent` to `kubeadapt-k8s-agent` and **did** update the pulse ci values to the new alias, but missed the agent ones.

Observed failure:

```
Failed to pull image "public.ecr.aws/w3l5x6r6/kubeadapt/app/kubeadapt-agent:v2.0.0":
  not found
Error: ErrImagePull -> ImagePullBackOff
Error: INSTALLATION FAILED: context deadline exceeded
```

## Change

Two lines in `charts/kubeadapt/ci/default-values.yaml`, pointing at the image the chart actually ships.

## Why this is not a guess

The replacement is corroborated three independent ways:

1. It matches the chart's own default in `charts/kubeadapt/values.yaml` on `main` (`k2x0t8t6/.../kubeadapt-k8s-agent`, tag `v3.0.1`)
2. It matches the pattern already used in `charts/kubeadapt-k8s-pulse/ci/default-values.yaml`, which #78 updated correctly
3. The tag was confirmed live against the public ECR registry API before editing

In the failing CI run, the pulse container was only `ContainerCreating` (still pulling) — **only** the agent image 404'd, which is consistent with pulse's values having been fixed and the agent's having been missed.

## Scope

This is a pre-existing repo defect, unrelated to any feature work. It is split out deliberately so it can be reviewed and landed on its own — it unblocks every open and future PR, not just mine.

Found while working on #85 (chart memory right-sizing), whose diff touches zero image references.
