### PR TITLE
chore(chart): bump pulse dependency pin to 1.0.1

### DIFF
--- a/charts/kubeadapt/Chart.yaml
+++ b/charts/kubeadapt/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: kubeadapt
 description: A Helm chart for Kubeadapt
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: "0.1.0"
 
 # Dependencies
 dependencies:
   - name: kubeadapt-k8s-pulse
-    version: "1.0.0"
+    version: "1.0.1"
     repository: "oci://ghcr.io/kubeadapt/kubeadapt-helm"
     condition: kubeadapt-k8s-pulse.enabled
 

--- a/charts/kubeadapt/README.md
+++ b/charts/kubeadapt/README.md
@@ -37,7 +37,7 @@ helm delete my-release
 
 | Repository | Name | Version |
 |------------|------|---------|
-| oci://ghcr.io/kubeadapt/kubeadapt-helm | kubeadapt-k8s-pulse | 1.0.0 |
+| oci://ghcr.io/kubeadapt/kubeadapt-helm | kubeadapt-k8s-pulse | 1.0.1 |
 
 ## Values
 

--- a/charts/kubeadapt/README.md
+++ b/charts/kubeadapt/README.md
@@ -1,6 +1,6 @@
 # kubeadapt
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 A Helm chart for Kubeadapt
 

--- a/charts/kubeadapt/upgrade-metadata.yaml
+++ b/charts/kubeadapt/upgrade-metadata.yaml
@@ -2,10 +2,11 @@
 # Defines explicit upgrade paths for this chart version.
 # This file is embedded in the chart package and used by KubeAdapt auto-upgrade system.
 
-chartVersion: "1.0.2"
+chartVersion: "1.0.3"
 
 # Versions that can upgrade to this version
 upgradeFrom:
+  - "1.0.2"
   - "1.0.1"
   - "1.0.0"
   - "0.18.6"


### PR DESCRIPTION
PR #85 raised the pulse memory request to 256Mi in the subchart source, but the parent chart pinned kubeadapt-k8s-pulse at 1.0.0 — so the change never reached any deployment. The vendored subchart directory is a gitignored helm dependency artifact, which is why the edit looked applied and silently was not.

pulse 1.0.1 was published by the Release Charts workflow on the #85 merge, and I confirmed it resolves before pinning to it:

    helm show chart oci://ghcr.io/kubeadapt/kubeadapt-helm/kubeadapt-k8s-pulse --version 1.0.1
    -> name: kubeadapt-k8s-pulse, version: 1.0.1

This completes the memory right-sizing started in #85. The agent half shipped immediately; this is the pulse half.

Parent chart 1.0.2 -> 1.0.3, with README badge and upgrade-metadata chartVersion/upgradeFrom synced as ct lint and the validate job require.