### PR TITLE
chore(chart): raise agent resource limits for large clusters

### DIFF
--- a/charts/kubeadapt/Chart.yaml
+++ b/charts/kubeadapt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kubeadapt
 description: A Helm chart for Kubeadapt
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: "0.1.0"
 
 # Dependencies
@@ -32,8 +32,8 @@ annotations:
     fingerprint: 3C8109B607AD3E119B7033D8948AD9EDA6BD626E
     url: https://kubeadapt.github.io/kubeadapt-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "Allow installing the chart in multiple namespaces simultaneously by suffixing cluster-scoped resource names (ClusterRole, ClusterRoleBinding) with the release namespace when it differs from the default 'kubeadapt' namespace. Existing installs in the default namespace are preserved unchanged."
+    - kind: changed
+      description: "Raise agent resource limits to 2000m CPU / 16Gi memory (from 1000m / 1Gi). The agent is a single Deployment per cluster, so its memory scales with total cluster size; the previous 1Gi limit bound at roughly 1000 nodes. A limit is a ceiling rather than a reservation, so the added headroom is not consumed on smaller clusters. Requests are unchanged at 100m / 256Mi so the chart still schedules on small clusters. See the sizing table in values.yaml."
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/prerelease: "true"
   artifacthub.io/license: Apache-2.0

--- a/charts/kubeadapt/README.md
+++ b/charts/kubeadapt/README.md
@@ -1,6 +1,6 @@
 # kubeadapt
 
-![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 A Helm chart for Kubeadapt
 
@@ -87,8 +87,8 @@ helm delete my-release
 | agent.image.tag | string | `"v3.0.1"` |  |
 | agent.nodeSelector | object | `{}` |  |
 | agent.rbac.create | bool | `true` |  |
-| agent.resources.limits.cpu | string | `"1000m"` |  |
-| agent.resources.limits.memory | string | `"1Gi"` |  |
+| agent.resources.limits.cpu | string | `"2000m"` |  |
+| agent.resources.limits.memory | string | `"16Gi"` |  |
 | agent.resources.requests.cpu | string | `"100m"` |  |
 | agent.resources.requests.memory | string | `"256Mi"` |  |
 | agent.service.type | string | `"ClusterIP"` |  |

--- a/charts/kubeadapt/upgrade-metadata.yaml
+++ b/charts/kubeadapt/upgrade-metadata.yaml
@@ -2,10 +2,11 @@
 # Defines explicit upgrade paths for this chart version.
 # This file is embedded in the chart package and used by KubeAdapt auto-upgrade system.
 
-chartVersion: "1.0.3"
+chartVersion: "1.0.4"
 
 # Versions that can upgrade to this version
 upgradeFrom:
+  - "1.0.3"
   - "1.0.2"
   - "1.0.1"
   - "1.0.0"

--- a/charts/kubeadapt/values.yaml
+++ b/charts/kubeadapt/values.yaml
@@ -28,16 +28,31 @@ agent:
     create: true
   service:
     type: ClusterIP
+  # ONE Deployment per cluster, so memory scales with TOTAL cluster size - a
+  # DaemonSet's stays flat per node. Peak is the network-flow merge, measured at
+  # ~1550 B per inbound flow row plus ~300 MB of caches at 5000 nodes. At 500
+  # flows per node per 60s window:
+  #
+  #     nodes    inbound rows    modelled peak
+  #       500            250k          ~0.44 GB
+  #      1000            500k          ~0.88 GB
+  #      2000              1M          ~1.7 GB
+  #      5000            2.5M          ~4.2 GB
+  #
+  # 16Gi carries 5000 nodes at ~4x headroom, and covers flow-heavy clusters
+  # (high pod fan-out, many distinct external destinations) where the per-node
+  # flow count runs 2-4x the 500 assumed above. A limit is a ceiling, not a
+  # reservation, so the unused headroom costs nothing on smaller clusters.
+  #
+  # Requests are deliberately NOT scaled with the limit: they are a scheduling
+  # floor and must keep the chart installable on small clusters.
   resources:
     requests:
-      # 141Mi measured on 3 nodes/208 pods (110% of the old 128Mi request).
-      # Scales with CLUSTER size - one Deployment merges all nodes - so this
-      # is a floor, not a validated 5000-node value.
       cpu: 100m
       memory: 256Mi
     limits:
-      cpu: 1000m
-      memory: 1Gi
+      cpu: 2000m
+      memory: 16Gi
 
   # ============================================================
   # Agent Configuration


### PR DESCRIPTION
## What

Raises agent resource limits from `1000m / 1Gi` to `2000m / 16Gi`. Requests unchanged at `100m / 256Mi`. Chart `1.0.3` -> `1.0.4`.

## Why

The agent is **one Deployment per cluster**, not a DaemonSet. Every node's pulse pushes into that single pod, so its memory scales with **total cluster size** while a DaemonSet's stays flat per node. The existing 1Gi limit was sized against a 3-node test cluster.

Peak heap is dominated by the network-flow merge, measured at **~1550 B per inbound flow row**, plus ~300 MB of informer/identity caches at 5000 nodes. At 500 distinct flows per node per 60s window:

| nodes | inbound rows | modelled peak |
|---|---|---|
| 500 | 250k | ~0.44 GB |
| 1000 | 500k | ~0.88 GB |
| 2000 | 1M | ~1.7 GB |
| 5000 | 2.5M | **~4.2 GB** |

**The current 1Gi limit therefore binds at roughly 1000 nodes.**

16Gi carries 5000 nodes at ~4x headroom and covers flow-heavy clusters (high pod fan-out, many distinct external destinations) where the per-node flow count runs 2-4x the 500 assumed above.

## Why requests are not raised

Requests are a **scheduling floor** and must keep the chart installable on small clusters. A limit is a ceiling, not a reservation, so the added headroom is not consumed on a 3-node cluster. Raising the request to match would break scheduling everywhere small.

This asymmetry is documented inline in `values.yaml` so it does not get "fixed" later.

## Reviewer note

A `256Mi` request against a `16Gi` limit is a 64x burstable ratio. **Please confirm this passes any LimitRange or ResourceQuota admission policy in target environments** — that is the one deployment-time risk here.

## Cascade

All five coupled locations updated together:

1. `Chart.yaml` version -> `1.0.4`
2. README version badge -> `1.0.4`
3. README values table -> `2000m` / `16Gi`
4. README dependency table — unchanged (no dependency bump)
5. `upgrade-metadata.yaml` — `chartVersion: 1.0.4`, `upgradeFrom` gains `1.0.3`

Plus the `artifacthub.io/changes` annotation.

## Verification

- `helm lint`: 1 chart linted, **0 failed**
- `helm template` renders `limits: 2000m / 16Gi`, `requests: 100m / 256Mi`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the agent’s default resource limits to 2 CPU and 16 GiB of memory.
  * Added guidance for estimating memory requirements based on cluster size.

* **Bug Fixes**
  * Clarified that resource requests remain fixed scheduling floors.

* **Documentation**
  * Updated version information and release notes for chart version 1.0.4.
  * Added upgrade support from chart version 1.0.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->